### PR TITLE
fix: failure due spindown

### DIFF
--- a/accumulator/invocation.go
+++ b/accumulator/invocation.go
@@ -79,7 +79,7 @@ func (inc *Invocation) MaybeCreateProxyTxn(status string, time time.Time) ([]byt
 	if err != nil {
 		return nil, err
 	}
-	if status != "success" {
+	if status != "success" && status != "spindown" {
 		txn, err = sjson.SetBytes(txn, "transaction.outcome", "failure")
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
### Contain
- [x] Bugfix

### Details
* Update transaction outcome definition to avoid mark `spindown` events as `failure`.

**PS.**: This is just a dirty and temporary patch, a proper solution is being done by the elastic team and as soon a new release  is available we can drop this one.